### PR TITLE
feat: Trigger build workflow on GitHub Release creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - main
+  release:
+    types: [created, published]
 
 jobs:
   build:


### PR DESCRIPTION
Updates the `.github/workflows/build.yml` to include a trigger for when a new GitHub Release is created or published.

The workflow will now run automatically:
- On pushes to `main` and `releases/**` branches.
- On pull requests targeting the `main` branch.
- When a new release is `created` or `published` via the GitHub UI/API.

This ensures that a build is performed when formal releases are made, aligning with common release management practices.