### PR TITLE
fix: Correct main branch name to master in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,11 @@ name: Android Build CI
 on:
   push:
     branches:
-      - main
+      - master
       - 'releases/**'
   pull_request:
     branches:
-      - main
+      - master
   release:
     types: [created, published]
 


### PR DESCRIPTION
Updates the `.github/workflows/build.yml` to use `master` as the main branch name instead of `main` in the trigger configurations for `push` and `pull_request` events.

This ensures the CI workflow correctly targets the primary development branch.